### PR TITLE
Move tokio to dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ fs-err = "2.9"
 log = "0.4"
 url = { version = "2", optional = true }
 data-url = { version = "0.2", optional = true }
-tokio = { version = ">=1.24.2", features = ["rt-multi-thread", "macros"], optional = true }
 reqwest = { version = "0.11", default-features = false, features = ["gzip", "brotli", "rustls-tls", "socks"], optional = true }
 backoff = { version = "0.4", features = ["tokio"], optional = true }
 tempfile = { version = "3", optional = true }
@@ -39,10 +38,11 @@ hex-literal = "0.3"
 colored = "2"
 indicatif = "0.17"
 clap = "4"
+tokio = { version = ">=1.24.2", features = ["rt-multi-thread", "macros"] }
 
 [features]
 default = ["fetch"]
-fetch = ["url", "data-url", "tokio", "reqwest", "backoff", "tempfile", "sanitise-file-name"]
+fetch = ["url", "data-url", "reqwest", "backoff", "tempfile", "sanitise-file-name"]
 libav = ["ac-ffmpeg"]
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This PR moves tokio to be a dev-dependency, so the `rt-multi-thread` and `macros` features aren't forced on the user.

Closes #6.