### PR TITLE
Event content and Binary content are base64 encoded

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
-serde_with = "2"
+serde_with = { version = "2", features = ["base64"] }
 quick-xml = { version = "0.28", features = ["serialize"] }
 chrono = { version = ">=0.4.20", features = ["serde"] }
 num-traits = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ use crate::libav::mux_audio_video;
 use crate::ffmpeg::mux_audio_video;
 use serde::{Serialize, Serializer, Deserialize};
 use serde::de;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none};
 use regex::Regex;
 use std::time::Duration;
 use chrono::DateTime;
@@ -1037,7 +1037,9 @@ pub struct Viewpoint {
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
+#[serde_as]
 pub struct Binary {
+    #[serde_as(as = "Base64")]
     #[serde(rename = "$value")]
     pub content: Vec<u8>,
 }
@@ -1060,6 +1062,7 @@ pub struct Signal {
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
+#[serde_as]
 pub struct Event {
     #[serde(rename = "@id")]
     pub id: Option<String>,
@@ -1085,8 +1088,9 @@ pub struct Event {
     pub schemeIdUri: Option<String>,
     #[serde(rename = "@value")]
     pub value: Option<String>,
+    #[serde_as(as = "Base64")]
     #[serde(rename = "$value")]
-    pub content: Option<String>,
+    pub content: Vec<u8>,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
Fixed a bug where Binary content was `Vec<u8>` but blows up because it needs to be converted from base64.  Also the content of Event itself if present, is also base64 - it's currently encoded/decoded as a String.   Or I could just make Binary an Option of String if you'd prefer.  Either change is not backward compat but to at least fix the parser from blowing up, we could just change the Binary content to be an Option of String.  Let me know.
