### PR TITLE
Update scte35 binary processing to use base64_serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ publish = true
 edition = "2021"
 
 [dependencies]
+base64 = "0.21"
+base64-serde = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "2", features = ["base64"] }
 quick-xml = { version = "0.28", features = ["serialize"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,18 +78,19 @@ use crate::scte35::Signal;
 use crate::libav::mux_audio_video;
 #[cfg(all(feature = "fetch", not(feature = "libav")))]
 use crate::ffmpeg::mux_audio_video;
+use base64_serde::base64_serde_type;
 use serde::{Serialize, Serializer, Deserialize};
 use serde::de;
-use serde_with::{serde_as, skip_serializing_none};
+use serde_with::skip_serializing_none;
 use regex::Regex;
 use std::time::Duration;
 use chrono::DateTime;
 
+base64_serde_type!(Base64Standard, base64::engine::general_purpose::STANDARD);
 
 /// Type representing an xs:dateTime, as per <https://www.w3.org/TR/xmlschema-2/#dateTime>
 // Something like 2021-06-03T13:00:00Z or 2022-12-06T22:27:53
 pub type XsDatetime = DateTime<chrono::offset::Utc>;
-
 
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
@@ -1038,7 +1039,6 @@ pub struct Viewpoint {
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
-#[serde_as]
 pub struct Event {
     #[serde(rename = "@id")]
     pub id: Option<String>,
@@ -1066,8 +1066,8 @@ pub struct Event {
     pub schemeIdUri: Option<String>,
     #[serde(rename = "@value")]
     pub value: Option<String>,
-    #[serde(rename = "$value")]
-    pub content: Option<String>,
+    #[serde(rename = "$value", with = "Base64Standard")]
+    pub content: Vec<u8>,
 }
 
 #[skip_serializing_none]

--- a/src/scte35.rs
+++ b/src/scte35.rs
@@ -16,17 +16,19 @@
 //
 // You won't often find public DASH streams with SCTE-35 events; they are more often used for
 // server-side ad insertion, which helps ensure that viewers benefit from the advertising content
-// instead of blocking or skipping it. For this reason, these definitions have not been well tested. 
+// instead of blocking or skipping it. For this reason, these definitions have not been well tested.
 //
 // An XML Schema for this embedding is available at
 // https://github.com/Comcast/scte35-go/blob/main/docs/scte_35_20220816.xsd
 
 
 #![allow(non_snake_case)]
+
+use base64_serde::base64_serde_type;
 use serde::{Serialize, Deserialize};
-use serde_with::{serde_as, skip_serializing_none};
+use serde_with::skip_serializing_none;
 
-
+base64_serde_type!(Base64Standard, base64::engine::general_purpose::STANDARD);
 
 pub fn serialize_scte35_ns<S>(os: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
 where S: serde::Serializer {
@@ -289,12 +291,10 @@ pub struct SpliceInfoSection {
 #[skip_serializing_none]
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 #[serde(default)]
-#[serde_as]
 pub struct Binary {
     #[serde(rename = "@signalType")]
     pub signal_type: Option<String>,
-    #[serde_as(as = "Base64")]
-    #[serde(rename = "$value")]
+    #[serde(rename = "$value", with = "Base64Standard")]
     pub content: Vec<u8>,
 }
 

--- a/tests/fixtures/aws.xml
+++ b/tests/fixtures/aws.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MPD id="201" minBufferTime="PT30S" profiles="urn:mpeg:dash:profile:isoff-main:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2013:xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"><BaseURL>https://10380e91fda5e303.mediapackage.us-west-2.amazonaws.com/out/v1/5f6a2197815e444a967f0c12f8325a11/</BaseURL>
         <Period duration="PT14.976S" id="8778696_PT0S_0" start="PT0S"><BaseURL>https://12345.mediatailor.us-west-2.amazonaws.com/v1/dashsegment/0d598fad40f42c4644d1c5b7674438772ee23b12/dash-vod-insertion/a5a7cf24-ee56-40e9-a0a2-82b483cf8650/8778696_PT0S/8778696_PT0S_0/</BaseURL>
+          <EventStream timescale="10000000" schemeIdUri="urn:scte:scte35:2014:xml+bin">
+            <Event>
+                <scte35:Signal>
+                    <scte35:Binary>/DAnAAAAAAAAAP/wBQb+0cr/PQARAg9DVUVJAAA0Q3+/AAAjAAAG6c2q</scte35:Binary>
+                </scte35:Signal>
+            </Event>
+          </EventStream>
           <AdaptationSet bitstreamSwitching="false" frameRate="30/1" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
             <SegmentTemplate startNumber="1" timescale="90000"/>
             <Representation bandwidth="3296000" codecs="avc1.64001f" height="720" id="1" width="1280">


### PR DESCRIPTION
This uses base64_serde and unlike the serde_as crate, seems to deserialize the base64 stuff okay. 