### PR TITLE
Pre-compile xs_duration regex for use in parsing MPDs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.21.5"
 base64-serde = "0.7.0"
+lazy_static = "1.4.0"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_path_to_error = "0.1.14"
 serde_ignored = { version = "0.1.9", optional = true }


### PR DESCRIPTION
We were doing some perf and memory testing / tuning of our application and noticed a lot of small allocations and overhead of compiling the regex for xs_duration (we have a lot of streams currently processing MPD updates every ~2s; we're not using fetch, but potentially the template url resolution there could benefit from this too though that's a much simpler regex).  Moving it to a static improved things a good deal.  This does introduce a dependency on lazy_static crate but there was already a transient dependency on it.  Let me know what you think.