### PR TITLE
Exclude tokio from wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,22 +28,24 @@ regex = "1.10.3"
 thiserror = "1.0.56"
 fs-err = "2.11.0"
 tracing = { version = "0.1.40", features = ["attributes"] }
-data-url = { version = "0.3.1", optional = true }
-reqwest = { version = "0.11.24", default-features = false, optional = true }
-tokio = { version = "1.36.0", features = ["rt-multi-thread", "time", "macros"] }
-backoff = { version = "0.4.0", features = ["tokio"], optional = true }
-governor = { version = "0.6.0", optional = true }
 xmltree = { version = "0.10.3", optional = true }
-async-recursion = { version = "1.0.5", optional = true }
-tempfile = { version = "3.10.0", optional = true }
-sanitise-file-name = { version = "1.0.0", optional = true }
 colored = { version = "2.0.4", optional = true }
 ac-ffmpeg = { version = "0.18.1", optional = true }
-ffprobe = { version = "0.3.3", optional = true }
 file-format = { version = "0.24.0", features = ["reader"], optional = true }
 bstr = { version = "1.9.0", optional = true }
 hex-literal = { version = "0.4.1", optional = true }
 pssh-box = { version = "0.1.1", optional = true }
+backoff = { version = "0.4.0", features = ["tokio"], optional = true }
+data-url = { version = "0.3.1", optional = true }
+reqwest = { version = "0.11.24", default-features = false, optional = true }
+governor = { version = "0.6.0", optional = true }
+async-recursion = { version = "1.0.5", optional = true }
+sanitise-file-name = { version = "1.0.0", optional = true }
+tempfile = { version = "3.10.0", optional = true }
+ffprobe = { version = "0.3.3", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.36.0", features = ["rt-multi-thread", "time", "macros"] }
 
 [dev-dependencies]
 sha2 = "0.10.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1955,7 +1955,7 @@ pub fn subtitle_type(a: &&AdaptationSet) -> SubtitleType {
     SubtitleType::Unknown
 }
 
-
+#[allow(unused)]
 fn content_protection_type(cp: &ContentProtection) -> String {
     if let Some(v) = &cp.value {
         if v.eq("cenc") {


### PR DESCRIPTION
Move the tokio dependency to allow the library to build (with --no-default-features) on wasm32.