### PR TITLE
Add support for <dashif:laurl>-tag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1227,7 +1227,7 @@ pub struct ContentProtection {
     /// The DRM key identifier.
     #[serde(rename = "@cenc:default_KID", alias = "@default_KID")]
     pub default_KID: Option<String>,
-    #[serde(rename = "clearkey:Laurl", alias = "Laurl")]
+    #[serde(rename = "clearkey:Laurl", alias = "Laurl", alias = "dashif:laurl", alias = "laurl")]
     pub laurl: Option<Laurl>,
     /// Content specific to initialization data using Microsoft PlayReady DRM.
     #[serde(rename = "mspr:pro", alias = "pro")]


### PR DESCRIPTION
The <dashif:laurl>-tag superseeds <clearkey:Laurl> with the same syntax.

More info:
https://dashif-documents.azurewebsites.net/Guidelines-Security/master/Guidelines-Security.html