### PR TITLE
Add 214 supplementalProfiles & supplementalCodecs attribs to Repr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,6 +1139,10 @@ pub struct Representation {
     pub href: Option<String>,
     #[serde(rename = "@xlink:actuate", alias = "@actuate")]
     pub actuate: Option<String>,
+    #[serde(rename = "@scte214:supplementalProfiles", alias = "@supplementalProfiles")]
+    pub scte214_supplemental_profiles: Option<String>,
+    #[serde(rename = "@scte214:supplementalCodecs", alias = "@supplementalCodecs")]
+    pub scte214_supplemental_codecs: Option<String>,
 }
 
 /// Describes a media content component.


### PR DESCRIPTION
Add scte214:supplementalProfiles and scte215:supplementalCodecs to Representation - used when there are alternate audio codecs, for example.