### PR TITLE
The scte214:supplementalProfiles and Codecs can live at AdaptationSet level as well

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,6 +1530,10 @@ pub struct AdaptationSet {
     #[serde(rename = "Representation")]
     pub representations: Vec<Representation>,
     pub ProducerReferenceTime: Option<ProducerReferenceTime>,
+    #[serde(rename = "@scte214:supplementalProfiles", alias = "@supplementalProfiles")]
+    pub scte214_supplemental_profiles: Option<String>,
+    #[serde(rename = "@scte214:supplementalCodecs", alias = "@supplementalCodecs")]
+    pub scte214_supplemental_codecs: Option<String>,
 }
 
 /// Identifies the asset to which a given Period belongs. Can be used to implement


### PR DESCRIPTION
I was informed (after [PR 67](https://github.com/emarsden/dash-mpd-rs/pull/67) was merged that these attributes can live at the AdaptationSet level as well.  Appreciated the quick merge and release of that and when you can, if you can review/merge this I would appreciate it so much.