### PR TITLE
Add support for the XML namespace prefix for the Microsoft PlayReady scheme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,15 @@ where S: serde::Serializer {
     }
 }
 
+fn serialize_mspr_ns<S>(os: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
+where S: serde::Serializer {
+    if let Some(s) = os {
+        serializer.serialize_str(s)
+    } else {
+        serializer.serialize_str("urn:microsoft:playready")
+    }
+}
+
 fn serialize_xlink_ns<S>(os: &Option<String>, serializer: S) -> Result<S::Ok, S::Error>
 where S: serde::Serializer {
     if let Some(s) = os {
@@ -1825,6 +1834,10 @@ pub struct MPD {
     #[serialize_always]
     #[serde(rename="@xmlns:cenc", alias="@cenc", serialize_with="serialize_cenc_ns")]
     pub cenc: Option<String>,
+    /// The XML namespace prefix used by convention for the Microsoft PlayReady scheme.
+    #[serialize_always]
+    #[serde(rename="@xmlns:mspr", alias="@mspr", serialize_with="serialize_mspr_ns")]
+    pub mspr: Option<String>,
     /// The XML namespace prefix used by convention for the XML Linking Language.
     #[serialize_always]
     #[serde(rename="@xmlns:xlink", alias="@xlink", serialize_with="serialize_xlink_ns")]


### PR DESCRIPTION
Why need this change?
* When deserializing and then serializing the MPD below, the XML namespace ‘mspr’ for the Microsoft PlayReady scheme is missing.
```
<MPD xmlns:cenc="urn:mpeg:cenc:2013" 
     xmlns="urn:mpeg:dash:schema:mpd:2011"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:mspr="urn:microsoft:playready"
     mediaPresentationDuration="PT3276.272949S"
     minBufferTime="PT8S"
     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011"
     type="static"
     xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
  <Period id="0">
    <AdaptationSet contentType="video"
                   frameRate="24000/1001"
                   id="0"
                   maxHeight="1080"
                   maxWidth="1920"
                   par="16:9"
                   subsegmentAlignment="true">
      <ContentProtection schemeIdUri="urn:mpeg:dash:mp4protection:2011"
                         cenc:default_KID="71e15509-d696-8226-29f4-f753654c9641"
                         value="cbcs"/>
      <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"
                         value="MSPR 2.0">
        <cenc:pssh>AAAB3nBzc2gAAA...A+AA==</cenc:pssh>
        <mspr:pro>vgEAAAEAAQC0ATw...FIAPgA=</mspr:pro>
      </ContentProtection>
...
```

Changes made
* Add support for the XML namespace prefix for the Microsoft PlayReady scheme