### PR TITLE
add new optional feature and alter fetch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ hex-literal = { version = "1.0.0", optional = true }
 pssh-box = { version = "0.1.11", optional = true }
 hxdmp = "0.2.1"
 webm-iterable = "0.6.4"
-
+ahash = {version = "0.8.12", optional = true }
 [dev-dependencies]
 sha2 = "0.10.9"
 hex-literal = "1.0.0"
@@ -89,6 +89,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 trust-dns = ["reqwest/trust-dns"]
 hickory-dns = ["reqwest/hickory-dns"]
 http2 = ["reqwest/http2"]
+fast-hash = ["ahash"]
 
 [target.'cfg(unix)'.dependencies]
 xattr = "1.5.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width=80


### PR DESCRIPTION
This pull request introduces an optional fast-hash feature that swaps Rust's default HashMap for the non-cryptographic [ahash::AHashMap](https://crates.io/crates/ahash), for faster performance in DASH media processing. It's fully backwards-compatible and off by default, just build with --features fast-hash to opt in. We frequently create HashMaps with a small set of known keys ("Number", "Time", "RepresentationID", "Bandwidth") to substitute values in DASH segment URLs, so the faster hashing could provide better performance gains during media downloading. Since this is client-side media processing rather than server-side request handling, there's low security risk from using a non-cryptographic hasher. See Nick Drozd's benchmarks for more details on AHash's performance gains [in this blog post](https://nickdrozd.github.io/2025/05/27/faster-hash.html).

**Note for maintainers:** Consider adding a unified rustfmt.toml configuration to ensure consistent code formatting across contributors.